### PR TITLE
Add support for building with conan and CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /int
 /lib
 /log
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,130 @@
+# -*- coding: utf-8; tab-width: 3; indent-tabs-mode: nil -*-
+#
+# Copyright 2017 Brent Dimmig
+#
+# This file is part of Lofty.
+#
+# Lofty is free software: you can redistribute it and/or modify it under the terms of version 2.1 of the GNU
+# Lesser General Public License as published by the Free Software Foundation.
+#
+# Lofty is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#-------------------------------------------------------------------------------------------------------------
+project(lofty)
+
+cmake_minimum_required(VERSION 2.8.12)
+add_definitions("-std=c++11 -fnon-call-exceptions -fvisibility=hidden -fdiagnostics-color=always -fPIC -ggdb -O0 -Wall -Wextra -pedantic -Wconversion -Wlogical-op -Wmissing-declarations -Wpacked -Wshadow -Wsign-conversion -Wundef")
+
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
+conan_basic_setup()
+
+include_directories(include)
+
+add_library(lofty
+   src/lofty/app.cxx
+   src/lofty/collections.cxx
+   src/lofty/collections/_pvt/hash_map_impl.cxx
+   src/lofty/collections/_pvt/trie_ordered_multimap_impl.cxx
+   src/lofty/collections/_pvt/vextr_impl.cxx
+   src/lofty/coroutine.cxx
+   src/lofty/exception.cxx
+   src/lofty/exception-throw_os_error.cxx
+   src/lofty/from_text_istream.cxx
+   src/lofty/io.cxx
+   src/lofty/io/binary.cxx
+   src/lofty/io/binary/default_buffered.cxx
+   src/lofty/io/binary/file-subclasses.cxx
+   src/lofty/io/text.cxx
+   src/lofty/io/text/binbuf.cxx
+   src/lofty/io/text/str.cxx
+   src/lofty/lofty.cxx
+   src/lofty/memory.cxx
+   src/lofty/net/ip.cxx
+   src/lofty/net/tcp.cxx
+   src/lofty/os.cxx
+   src/lofty/os/path.cxx
+   src/lofty/perf/stopwatch.cxx
+   src/lofty/process.cxx
+   src/lofty/_pvt/signal_dispatcher.cxx
+   src/lofty/_std.cxx
+   src/lofty/text.cxx
+   src/lofty/text/char_ptr_to_str_adapter.cxx
+   src/lofty/text/char_traits.cxx
+   src/lofty/text/parsers/ansi_escape_sequences.cxx
+   src/lofty/text/parsers/dynamic.cxx
+   src/lofty/text/parsers/regex.cxx
+   src/lofty/text/str.cxx
+   src/lofty/text/str_traits.cxx
+   src/lofty/text/ucd.cxx
+   src/lofty/thread.cxx
+   src/lofty/to_text_ostream.cxx
+)
+target_link_libraries(lofty dl pthread)
+
+add_library(lofty-testing
+   src/lofty-testing/lofty-testing.cxx
+)
+target_link_libraries(lofty-testing lofty)
+
+add_executable(lofty-test
+   test/lofty/collections/hash_map.cxx
+   test/lofty/collections/list.cxx
+   test/lofty/collections/queue.cxx
+   test/lofty/collections/static_list.cxx
+   test/lofty/collections/trie_ordered_multimap.cxx
+   test/lofty/collections/vector.cxx
+   test/lofty/coroutine.cxx
+   test/lofty/exception.cxx
+   test/lofty/from_text_istream.cxx
+   test/lofty/io/binary/pipe.cxx
+   test/lofty/io/text/binbuf_istream-read.cxx
+   test/lofty/io/text/istream-scan.cxx
+   test/lofty/io/text/ostream-print.cxx
+   test/lofty/lofty-test.cxx
+   test/lofty/net.cxx
+   test/lofty/os/path.cxx
+   test/lofty/process.cxx
+   test/lofty/text/parsers/dynamic.cxx
+   test/lofty/text/str.cxx
+   test/lofty/text/str_traits.cxx
+   test/lofty/thread.cxx
+   test/lofty/to_text_ostream.cxx
+)
+target_link_libraries(lofty-test lofty-testing lofty)
+
+add_executable(hello-world
+   examples/hello-world.cxx
+)
+target_link_libraries(hello-world lofty)
+
+add_executable(cat
+   examples/cat.cxx
+)
+target_link_libraries(cat lofty)
+
+add_executable(exceptions
+   examples/exceptions.cxx
+)
+target_link_libraries(exceptions lofty)
+
+add_executable(coroutines
+   examples/coroutines.cxx
+)
+target_link_libraries(coroutines lofty)
+
+add_executable(echo-server
+   examples/echo-server.cxx
+)
+target_link_libraries(echo-server lofty)
+
+add_executable(http-server
+   examples/http-server.cxx
+)
+target_link_libraries(http-server lofty)
+
+add_executable(maps-comparison
+   examples/maps-comparison.cxx
+)
+target_link_libraries(maps-comparison lofty)
+

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ See § _4. Versioning and branching_ for more information on available branches.
 
 ### 2.1. Building
 
-Building Lofty requires [Complemake](https://github.com/raffaellod/complemake), which works as an improved
+#### Complemake
+
+Building Lofty is easiest with [Complemake](https://github.com/raffaellod/complemake), which works as an improved
 make utility and dependency manager.
 
 To build Lofty, run Complemake from Lofty’s repo clone:
@@ -49,6 +51,19 @@ complemake build
 ```
 
 This will create outputs in the `bin` and `lib` folders (you can change that with Complemake’s flags).
+
+#### Conan and CMake
+
+Alternatively, Lofty can also be built as a [Conan](https://www.conan.io/) package
+with [CMake](https://cmake.org/).
+
+With Conan and CMake installed, build Lofty by running the following commands from Lofty’s repo clone:
+```
+conan install .
+conan build .
+```
+
+This will create outputs in the `bin` and `lib` folders.
 
 
 ### 2.2. Installing

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+# -*- coding: utf-8; mode: python; tab-width: 3; indent-tabs-mode: nil -*-
+#
+# Copyright 2017 Brent Dimmig
+#
+# This file is part of Lofty.
+#
+# Lofty is free software: you can redistribute it and/or modify it under the terms of version 2.1 of the GNU
+# Lesser General Public License as published by the Free Software Foundation.
+#
+# Lofty is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License
+# for more details.
+#-------------------------------------------------------------------------------------------------------------
+
+from conans import ConanFile, CMake
+
+
+class LoftyConan(ConanFile):
+    name = "lofty"
+    version = "0.2.1"
+    license = "LGPL-2.1"
+    url = "https://github.com/raffaellod/lofty"
+    description = "Coroutines, stack traces and smart I/O for C++11, inspired by Python and Golang."
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False]}
+    default_options = "shared=True"
+    generators = "cmake"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure(source_dir=self.source_folder)
+        cmake.build()
+
+    def package(self):
+        self.copy(pattern="*.hxx", dst="include", src="include")
+        self.copy("*.so", dst="lib", keep_path=False)
+        self.copy("*.dylib", dst="lib", keep_path=False)
+
+    def package_info(self):
+        self.cpp_info.libs = ["lofty"]
+


### PR DESCRIPTION
Created a `CMakeLists.txt` file and `conanfile.py` which allow building as a [Conan](https://www.conan.io/) package with CMake.

The CMake file was directly ported from the [Complemake](https://github.com/raffaellod/lofty/blob/master/lofty.comk) build file.